### PR TITLE
Change the default qtype to AAAA.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,13 @@ Breaking changes
 
 New
 
+* Added a new `lookup` command. ([#10])
+
 Bug fixes
 
 Other changes
+
+[#10]: https://github.com/NLnetLabs/dnsi/pull/10
 
 
 ## 0.1.0

--- a/doc/dnsi-query.1
+++ b/doc/dnsi-query.1
@@ -22,7 +22,7 @@ If
 .I query_type
 is given, it provides the record type to be queried for. If it is missing,
 the record type
-.B A
+.B AAAA
 is used.
 
 A specific name server and port can be selected through the

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -29,7 +29,7 @@ pub struct Query {
     qname: Name<Vec<u8>>,
 
     /// The record type to look up
-    #[arg(value_name="QUERY_TYPE", default_value = "A")]
+    #[arg(value_name="QUERY_TYPE", default_value = "AAAA")]
     qtype: Rtype,
 
     /// The server to send the query to. System servers used if missing


### PR DESCRIPTION
This PR changes the default query type of the `query` command to AAAA.