### PR TITLE
rename enum Commands to Command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,13 +1,13 @@
 //! Global configuration.
 
-use super::commands::Commands;
+use super::commands::Command;
 use super::error::Error;
 
 
 #[derive(Clone, Debug, clap::Parser)]
 pub struct Args {
     #[command(subcommand)]
-    command: Commands,
+    command: Command,
 }
 
 impl Args {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,7 +9,7 @@ use super::error::Error;
 
 
 #[derive(Clone, Debug, clap::Subcommand)]
-pub enum Commands {
+pub enum Command {
     /// Query the DNS.
     Query(self::query::Query),
 
@@ -20,7 +20,7 @@ pub enum Commands {
     Man(self::help::Help),
 }
 
-impl Commands {
+impl Command {
     pub fn execute(self) -> Result<(), Error> {
         match self {
             Self::Query(query) => query.execute(),


### PR DESCRIPTION
Aligning with the general convention of having singular enums, the enum `Commands` is renamed to `Command`