### PR TITLE
Don't add padding to the last cell in tables (and some more comments)

### DIFF
--- a/src/output/table_writer.rs
+++ b/src/output/table_writer.rs
@@ -35,8 +35,11 @@ impl<const N: usize> TableWriter<'_, N> {
             right_aligned,
         } = self;
 
+        // This contains the widths of all the columns, which we need to
+        // print everything with the correct alignment.
         let mut widths = [0; N];
 
+        // The header contributes to the widths only if its present.
         if let Some(header) = header {
             for i in 0..N {
                 widths[i] = header[i].len();
@@ -72,7 +75,10 @@ impl<const N: usize> TableWriter<'_, N> {
         }
 
         for row in *rows {
+            // First we write the indent of the entire table
             write!(target, "{indent}")?;
+
+            // Print every cell in this row **except** the last cell
             for &i in &columns[..columns.len() - 1] {
                 if right_aligned[i] {
                     write!(target, "{:>width$}", row[i], width = widths[i])?;
@@ -81,6 +87,10 @@ impl<const N: usize> TableWriter<'_, N> {
                 }
                 write!(target, "{spacing}")?;
             }
+
+            // The last cell in the row is printed separately, because it
+            // doesn't need spacing. It also does not need padding if it is
+            // left-aligned.
             let last = columns[columns.len() - 1];
             if right_aligned[last] {
                 write!(
@@ -90,13 +100,11 @@ impl<const N: usize> TableWriter<'_, N> {
                     width = widths[last]
                 )?;
             } else {
-                write!(
-                    target,
-                    "{:<width$}",
-                    row[last],
-                    width = widths[last]
-                )?;
+                // It's the last cell; no padding needed
+                write!(target, "{}", row[last],)?;
             }
+
+            // Print a newline
             writeln!(target)?;
         }
 


### PR DESCRIPTION
This is important for when data in the last column gets really big where the padding will wrap in the terminal and add a lot of unnecessary blank lines. For example in this query:
```
> dnsi query --tls --server one.one.one.one nlnetlabs.nl
HEADER
  opcode:   QUERY
  rcode:    NOERROR
  id:       0
  flags:    QR RD RA
  records:  QUESTION: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

OPT PSEUDOSECTION
  EDNS     version: 0; flags: false; udp: 1232
  PADDING  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ()

QUESTION SECTION
  Name            Type
  nlnetlabs.nl    AAAA

ANSWER SECTION
  Owner           TTL       Type    Data                
  nlnetlabs.nl    4m  0s    AAAA    2a01:4f8:c0c:cdfa::1

EXTRA INFO
  When:           Tue Jun 25 13:15:13 +02:00 2024
  Query time:     62 msec
  Server:         2606:4700:4700::1111#853
  Protocol:       TLS
  Response size:  468 bytes
```

This is based on a suggestion by @Philip-NLnetLabs 