### PR TITLE
Show the default query QTYPE in the CLI help.

### DIFF
--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -28,7 +28,7 @@ pub struct Query {
     qname: NameOrAddr,
 
     /// The record type to look up
-    #[arg(value_name = "QUERY_TYPE")]
+    #[arg(value_name = "QUERY_TYPE", default_value = "AAAA or PTR")]
     qtype: Option<Rtype>,
 
     /// The server to send the query to. System servers used if missing


### PR DESCRIPTION
```
Query the DNS

Usage: dnsi query [OPTIONS] <QUERY_NAME_OR_ADDR> [QUERY_TYPE]

Arguments:
  <QUERY_NAME_OR_ADDR>
          The name of the resource records to look up

  [QUERY_TYPE]
          The record type to look up
          
          [default: "AAAA or PTR"]
```

This PR adds the last line of that help text.