### PR TITLE
Additional support relating to IXFR.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.78.0, stable, beta, nightly]
+        rust: [1.79.0, stable, beta, nightly]
     env:
         RUSTFLAGS: "-D warnings"
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.10.3"
-source = "git+https://github.com/NLnetLabs/domain.git#e5ace3f15275073caa8c7ff6c34d6a4c1123b948"
+source = "git+https://github.com/NLnetLabs/domain.git?rev=e5ace3f1#e5ace3f15275073caa8c7ff6c34d6a4c1123b948"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dnsi"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.79.0"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "A tool for investigating the DNS."
 repository = "https://github.com/nlnetlabs/dnsi/"
@@ -16,7 +16,7 @@ exclude = [ ".github", ".gitignore" ]
 bytes    = "1"
 clap     = { version = "4", features = ["derive", "unstable-doc"] }
 chrono   = { version = "0.4.38", features = [ "alloc", "clock" ] }
-domain   = { git = "https://github.com/NLnetLabs/domain.git", features = ["resolv", "unstable-client-transport"]}
+domain   = { git = "https://github.com/NLnetLabs/domain.git", rev="e5ace3f1", features = ["resolv", "unstable-client-transport"]}
 tempfile = "3.1.0"
 tokio    = { version = "1.33", features = ["rt-multi-thread"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [ "ring", "logging", "tls12" ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -122,8 +122,8 @@ impl Client {
         server: &Server,
     ) -> Result<(Box<dyn GetResponseMulti>, Stats, Box<dyn SendRequestMulti<RequestMessageMulti<Vec<u8>>>>), Error> {
         match server.transport {
-            Transport::Udp => todo!(),
-            Transport::UdpTcp => todo!(),
+            Transport::Udp => unreachable!(),
+            Transport::UdpTcp => unreachable!(),
             Transport::Tcp => self.request_tcp_multi(request, server).await,
             Transport::Tls => self.request_tls_multi(request, server).await,
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -122,8 +122,8 @@ impl Client {
         server: &Server,
     ) -> Result<(Box<dyn GetResponseMulti>, Stats, Box<dyn SendRequestMulti<RequestMessageMulti<Vec<u8>>>>), Error> {
         match server.transport {
-            Transport::Udp => unreachable!(),
-            Transport::UdpTcp => unreachable!(),
+            Transport::Udp => todo!(),
+            Transport::UdpTcp => todo!(),
             Transport::Tcp => self.request_tcp_multi(request, server).await,
             Transport::Tls => self.request_tls_multi(request, server).await,
         }

--- a/src/commands/xfr.rs
+++ b/src/commands/xfr.rs
@@ -297,7 +297,7 @@ impl Xfr {
         if self.tls {
             Transport::Tls
         } else if self.udp {
-            Transport::UdpTcp
+            Transport::Udp
         } else {
             Transport::Tcp
         }

--- a/src/commands/xfr.rs
+++ b/src/commands/xfr.rs
@@ -87,9 +87,8 @@ impl Xfr {
         // using UDP" but as RFC 9103 section 5.2 states "it is noted that
         // most of the widely used open-source implementations of
         // authoritative name servers (including both [BIND] and [NSD]) do
-        // IXFR using TCP by default in their latest releases" and thus we
-        // default to TCP for IXFR, using UDP first must be requested
-        // explicity.
+        // IXFR using TCP by default in their latest releases" we default to
+        // TCP for IXFR, using UDP first must be requested explicity.
         if self.udp && self.ixfr.is_none() {
             // Based on https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html#custom-validation.
             let mut cmd = Args::command();

--- a/src/commands/xfr.rs
+++ b/src/commands/xfr.rs
@@ -81,9 +81,11 @@ pub struct Xfr {
 impl Xfr {
     pub fn execute(self) -> Result<(), Error> {
         // Per RFC 5936 section 4.2 "AXFR sessions over UDP transport are not
-        // defined". RFC 1995 section 2 "a client should first make an IXFR
-        // query using UDP" but as RFC 9103 section 5.2 states "it is noted
-        // that most of the widely used open-source implementations of
+        // defined".
+        //
+        // RFC 1995 section 2 says "a client should first make an IXFR query
+        // using UDP" but as RFC 9103 section 5.2 states "it is noted that
+        // most of the widely used open-source implementations of
         // authoritative name servers (including both [BIND] and [NSD]) do
         // IXFR using TCP by default in their latest releases" and thus we
         // default to TCP for IXFR, using UDP first must be requested

--- a/src/commands/xfr.rs
+++ b/src/commands/xfr.rs
@@ -57,7 +57,7 @@ pub struct Xfr {
     udp: bool,
 
     /// When trying UDP first, do NOT fallback to TCP.
-    /// 
+    ///
     /// Only permitted with IXFR via UDP.
     #[arg(short, long)]
     notcp: bool,
@@ -349,7 +349,7 @@ impl Xfr {
         let res = MessageBuilder::new_vec();
 
         let mut res = res.question();
-        let add = match self.ixfr {
+        match self.ixfr {
             None => {
                 res.push((&self.qname.to_name(), Rtype::AXFR)).unwrap();
                 res.additional()
@@ -369,8 +369,7 @@ impl Xfr {
                 auth.push((&self.qname.to_name(), 0, soa)).unwrap();
                 auth.additional()
             }
-        };
-        add
+        }
     }
 }
 

--- a/src/commands/xfr.rs
+++ b/src/commands/xfr.rs
@@ -57,6 +57,8 @@ pub struct Xfr {
     udp: bool,
 
     /// When trying UDP first, do NOT fallback to TCP.
+    /// 
+    /// Only permitted with IXFR via UDP.
     #[arg(short, long)]
     notcp: bool,
 

--- a/src/commands/xfr.rs
+++ b/src/commands/xfr.rs
@@ -161,6 +161,7 @@ impl Xfr {
     }
 
     async fn do_tcp_xfr(mut self) -> Result<(), Error> {
+        eprintln!("XIMON: do_tcp_xfr()");
         let client = self.mk_client(self.transport()).await?;
         let (mut get_resp, mut stats, _conn) =
             client.request_multi(self.create_multi_request()?).await?;
@@ -184,6 +185,7 @@ impl Xfr {
     async fn do_udp_xfr_with_tcp_fallback(
         mut self,
     ) -> Result<(), Error> {
+        eprintln!("XIMON: do_udp_xfr_with_tcp_fallback()");
         let client = self.mk_client(Transport::Udp).await?;
         let ans = client.request(self.create_request()?).await?;
 


### PR DESCRIPTION
This PR builds on PR #44 to add support for two behaviours defined in RFC 1995 "Incremental Zone Transfer in DNS
" (aka IXFR): 
-  _"a client should first make an IXFR query using UDP"_: Optional support for this is added via a new `--udp` argument to the `xfr` command. The rationale for making it optional is that RFC 9103 notes that _"most of the widely used open-source implementations of authoritative name servers (including both [BIND] and [NSD]) do IXFR using TCP by default in their latest releases"_, i.e. the expected norm for operators is for IXFR to use TCP just like AXFR and not UDP. The new `--udp` argument is only allowed if `--ixfr <N>` was also used.
- _"If the UDP reply does not fit, the query is responded to with a single SOA record of the server's current version to inform the client that a TCP query should be initiated."_: When using `--udp` an RFC 1995 compliant server signals truncation via a SOA response instead of setting TC=1, so this PR detects that special response and retries in that event via TCP. Also relating to this is new command line argument `--notcp` for the `xfr` command, only allowed if `--udp` was also used, which disables the fallback. This is useful for allowing the caller to inspect the initial response rather than hiding it by retrying and returning only the final TCP response. 

This PR lacks unit tests. It has however been tested by using it to replace uses of `dig` and `drill` for XFR transfers performed in the OpenDNSSEC `test-cases.d` test suite.

Note: it also has some re-ordering and formatting of code and imports that doesn't strictly relate to the PR.